### PR TITLE
feat(access): add user allowlist and clickable mentions in block messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,9 @@ PERSONA_MESSAGE=""               # optional answer style / tone (e.g. "자연스
 
 # --- Access control / throttle ---
 ALLOWED_CHANNEL_IDS=""           # comma-separated channel IDs, empty = allow all
-ALLOWED_CHANNEL_MESSAGE=""       # reply sent when channel not allowed
+ALLOWED_CHANNEL_MESSAGE=""       # reply sent when channel not allowed; "{}" → first allowed channel
+ALLOWED_USER_IDS=""              # comma-separated user IDs, empty = allow all (applies to DMs too)
+ALLOWED_USER_MESSAGE=""          # reply sent when user not allowed; "{}" → first allowed user
 MAX_THROTTLE_COUNT=100           # per-user active request cap
 
 # --- Storage (DynamoDB — created by serverless deploy) ---

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -74,6 +74,8 @@ jobs:
           # --- vars: Access control / throttle ---
           ALLOWED_CHANNEL_IDS: ${{ vars.ALLOWED_CHANNEL_IDS }}
           ALLOWED_CHANNEL_MESSAGE: ${{ vars.ALLOWED_CHANNEL_MESSAGE }}
+          ALLOWED_USER_IDS: ${{ vars.ALLOWED_USER_IDS }}
+          ALLOWED_USER_MESSAGE: ${{ vars.ALLOWED_USER_MESSAGE }}
           MAX_THROTTLE_COUNT: ${{ vars.MAX_THROTTLE_COUNT }}
           # --- vars: Storage ---
           MAX_HISTORY_CHARS: ${{ vars.MAX_HISTORY_CHARS }}

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ Slack 멘션·DM 을 AWS Lambda 에서 처리하고, OpenAI · AWS Bedrock · xA
 | `DYNAMODB_TABLE_NAME` | | `lambda-gurumi-bot-dev` | dedup / 대화 저장 테이블 |
 | `AWS_REGION` | | `us-east-1` | AWS 리전 |
 | `ALLOWED_CHANNEL_IDS` | | (empty) | 콤마 구분. 비어있으면 모든 채널 허용. **DM(`message.im`) 은 허용 리스트 대상이 아님** — allowlist 를 설정해도 DM 경로는 항상 허용됨 |
-| `ALLOWED_CHANNEL_MESSAGE` | | — | 비허용 채널 응답 메시지 (DM 에는 적용되지 않음) |
+| `ALLOWED_CHANNEL_MESSAGE` | | — | 비허용 채널 응답 메시지 (DM 에는 적용되지 않음). `{}` 가 있으면 `ALLOWED_CHANNEL_IDS` 의 첫 채널을 `<#ID>` 멘션 형태로 치환 |
+| `ALLOWED_USER_IDS` | | (empty) | 콤마 구분. 비어있으면 모든 유저 허용. **채널·DM 모든 경로에 적용** — DM 도 차단 |
+| `ALLOWED_USER_MESSAGE` | | — | 비허용 유저 응답 메시지. `{}` 가 있으면 `ALLOWED_USER_IDS` 의 첫 유저를 `<@ID>` 멘션 형태로 치환 |
 | `MAX_LEN_SLACK` | | `3000` | 메시지 분할 기준 (≥500). `.env.example` · `serverless.yml` 기본 `3000`, 미지정 시 `config.py` 폴백 `2000`. |
 | `MAX_OUTPUT_TOKENS` | | `4096` | LLM hop 당 출력 토큰 상한 (≥256) |
 | `MAX_THROTTLE_COUNT` | | `100` | 유저별 동시 요청 상한 |
@@ -128,7 +130,7 @@ aws iam attach-role-policy --role-name "${NAME}" --policy-arn "arn:aws:iam::${AC
 ### 2. GitHub 저장소 설정
 
 - **Secrets**: `AWS_ACCOUNT_ID`, `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `OPENAI_API_KEY`, `XAI_API_KEY`(xAI 사용 시), `TAVILY_API_KEY`(선택)
-- **Variables**: `LLM_PROVIDER`, `LLM_MODEL`, `IMAGE_PROVIDER`, `IMAGE_MODEL`, `RESPONSE_LANGUAGE`, `ALLOWED_CHANNEL_IDS`, `ALLOWED_CHANNEL_MESSAGE`, `SYSTEM_MESSAGE`, `PERSONA_MESSAGE`, `BOT_CURSOR`, `MAX_LEN_SLACK`, `MAX_OUTPUT_TOKENS`, `MAX_THROTTLE_COUNT`, `MAX_HISTORY_CHARS`, `AGENT_MAX_STEPS`, `LOG_LEVEL`, `DEFAULT_TIMEZONE`, `MAX_DOC_CHARS`, `MAX_DOC_PAGES`, `MAX_DOC_BYTES`, `MAX_WEB_CHARS`, `MAX_WEB_BYTES`, `MAX_WEB_LINKS`, `JINA_READER_BASE`
+- **Variables**: `LLM_PROVIDER`, `LLM_MODEL`, `IMAGE_PROVIDER`, `IMAGE_MODEL`, `RESPONSE_LANGUAGE`, `ALLOWED_CHANNEL_IDS`, `ALLOWED_CHANNEL_MESSAGE`, `ALLOWED_USER_IDS`, `ALLOWED_USER_MESSAGE`, `SYSTEM_MESSAGE`, `PERSONA_MESSAGE`, `BOT_CURSOR`, `MAX_LEN_SLACK`, `MAX_OUTPUT_TOKENS`, `MAX_THROTTLE_COUNT`, `MAX_HISTORY_CHARS`, `AGENT_MAX_STEPS`, `LOG_LEVEL`, `DEFAULT_TIMEZONE`, `MAX_DOC_CHARS`, `MAX_DOC_PAGES`, `MAX_DOC_BYTES`, `MAX_WEB_CHARS`, `MAX_WEB_BYTES`, `MAX_WEB_LINKS`, `JINA_READER_BASE`
 
 ### 3. 배포
 

--- a/app.py
+++ b/app.py
@@ -253,6 +253,21 @@ def _process(event: dict, client, say, is_dm: bool) -> None:  # noqa: ANN001
         log_event(logger, "channel.blocked", channel=channel)
         return
 
+    # User allowlist applies to channels AND DMs. Unlike the channel allowlist
+    # (which exempts DMs because DM channel IDs are D-prefixed and wouldn't
+    # be enrolled), restricting *who* can talk to the bot is meaningful in
+    # both directions — arguably more so in DMs, where there's no channel-
+    # level gate at all. Operator opts in via ALLOWED_USER_IDS; empty list
+    # means everyone is allowed.
+    if settings.allowed_user_ids and user not in settings.allowed_user_ids:
+        msg = settings.allowed_user_message or ""
+        if msg and "{}" in msg:
+            msg = msg.replace("{}", f"<@{settings.allowed_user_ids[0]}>")
+        if msg:
+            say(text=msg, thread_ts=thread_ts)
+        log_event(logger, "user.blocked", user=user, channel=channel)
+        return
+
     try:
         active = dedup.count_user_active(user)
     except Exception as exc:  # noqa: BLE001

--- a/app.py
+++ b/app.py
@@ -246,6 +246,8 @@ def _process(event: dict, client, say, is_dm: bool) -> None:  # noqa: ANN001
     # workspace install permission already gates who can open the DM.
     if not is_dm and not channel_allowed(channel, settings.allowed_channel_ids):
         msg = settings.allowed_channel_message or ""
+        if msg and "{}" in msg and settings.allowed_channel_ids:
+            msg = msg.replace("{}", f"<#{settings.allowed_channel_ids[0]}>")
         if msg:
             say(text=msg, thread_ts=thread_ts)
         log_event(logger, "channel.blocked", channel=channel)

--- a/serverless.yml
+++ b/serverless.yml
@@ -49,6 +49,8 @@ provider:
     # --- vars: Access control / throttle ---
     ALLOWED_CHANNEL_IDS: ${env:ALLOWED_CHANNEL_IDS, ''}
     ALLOWED_CHANNEL_MESSAGE: ${env:ALLOWED_CHANNEL_MESSAGE, ''}
+    ALLOWED_USER_IDS: ${env:ALLOWED_USER_IDS, ''}
+    ALLOWED_USER_MESSAGE: ${env:ALLOWED_USER_MESSAGE, ''}
     MAX_THROTTLE_COUNT: ${env:MAX_THROTTLE_COUNT, '100'}
     # --- vars: Storage ---
     MAX_HISTORY_CHARS: ${env:MAX_HISTORY_CHARS, '4000'}

--- a/src/config.py
+++ b/src/config.py
@@ -140,7 +140,7 @@ class Settings:
             dynamodb_table_name=os.getenv("DYNAMODB_TABLE_NAME", "lambda-gurumi-bot-dev").strip(),
             aws_region=os.getenv("AWS_REGION", "us-east-1").strip(),
             allowed_channel_ids=_list_env("ALLOWED_CHANNEL_IDS"),
-            allowed_channel_message=os.getenv("ALLOWED_CHANNEL_MESSAGE", "").strip(),
+            allowed_channel_message=os.getenv("ALLOWED_CHANNEL_MESSAGE", "구루미에게 질문은 {} 채널을 이용해 주세요~").strip(),
             max_len_slack=_int_env("MAX_LEN_SLACK", 2000, minimum=500),
             max_throttle_count=_int_env("MAX_THROTTLE_COUNT", 100, minimum=1),
             max_history_chars=_int_env("MAX_HISTORY_CHARS", 4000, minimum=500),

--- a/src/config.py
+++ b/src/config.py
@@ -96,6 +96,8 @@ class Settings:
     aws_region: str
     allowed_channel_ids: list[str] = field(default_factory=list)
     allowed_channel_message: str = ""
+    allowed_user_ids: list[str] = field(default_factory=list)
+    allowed_user_message: str = ""
     max_len_slack: int = 3000
     max_throttle_count: int = 100
     max_history_chars: int = 4000
@@ -141,6 +143,8 @@ class Settings:
             aws_region=os.getenv("AWS_REGION", "us-east-1").strip(),
             allowed_channel_ids=_list_env("ALLOWED_CHANNEL_IDS"),
             allowed_channel_message=os.getenv("ALLOWED_CHANNEL_MESSAGE", "구루미에게 질문은 {} 채널을 이용해 주세요~").strip(),
+            allowed_user_ids=_list_env("ALLOWED_USER_IDS"),
+            allowed_user_message=os.getenv("ALLOWED_USER_MESSAGE", "허용된 유저만 응답합니다.").strip(),
             max_len_slack=_int_env("MAX_LEN_SLACK", 2000, minimum=500),
             max_throttle_count=_int_env("MAX_THROTTLE_COUNT", 100, minimum=1),
             max_history_chars=_int_env("MAX_HISTORY_CHARS", 4000, minimum=500),

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -426,3 +426,130 @@ def test_process_blocked_channel_no_message_when_unset(app_module, monkeypatch):
     )
 
     assert posts == []
+
+
+# --------------------------------------------------------------------------- #
+# User allowlist — block reply with first-user substitution (channel + DM)
+# --------------------------------------------------------------------------- #
+
+
+def test_process_blocked_user_substitutes_first_allowed_user(app_module, monkeypatch):
+    """비허용 유저 응답의 `{}` 는 ALLOWED_USER_IDS 의 첫 번째 유저를
+    Slack 멘션 형식(`<@ID>`)으로 치환해야 한다. 채널 검사를 통과한 뒤에도 유저로
+    차단되는 케이스."""
+    import dataclasses
+
+    override = dataclasses.replace(
+        app_module.settings,
+        allowed_channel_ids=[],  # 채널 검사 통과
+        allowed_user_ids=["U-ADMIN", "U-OPS"],
+        allowed_user_message="이 봇은 {} 만 답변합니다.",
+    )
+    monkeypatch.setattr(app_module, "settings", override)
+    monkeypatch.setattr(app_module, "_get_dedup", lambda: _FakeDedup())
+
+    posts = []
+    app_module._process(
+        {
+            "channel": "C-OK",
+            "ts": "1.1",
+            "text": "hi",
+            "user": "U-RANDOM",
+            "client_msg_id": "msg-user-1",
+        },
+        client=object(),
+        say=lambda text, thread_ts=None: posts.append({"text": text, "thread_ts": thread_ts}),
+        is_dm=False,
+    )
+
+    assert posts == [{"text": "이 봇은 <@U-ADMIN> 만 답변합니다.", "thread_ts": "1.1"}]
+
+
+def test_process_blocked_user_applies_in_dm(app_module, monkeypatch):
+    """유저 화이트리스트는 DM 경로에도 적용되어야 한다 — 채널 화이트리스트와의
+    핵심 차이. is_dm=True 라도 비허용 유저는 차단 메시지를 받는다."""
+    import dataclasses
+
+    override = dataclasses.replace(
+        app_module.settings,
+        allowed_user_ids=["U-ADMIN"],
+        allowed_user_message="DM 도 차단합니다.",
+    )
+    monkeypatch.setattr(app_module, "settings", override)
+    monkeypatch.setattr(app_module, "_get_dedup", lambda: _FakeDedup())
+
+    posts = []
+    app_module._process(
+        {
+            "channel": "D-DM",
+            "ts": "1.1",
+            "text": "hi",
+            "user": "U-RANDOM",
+            "client_msg_id": "msg-user-2",
+        },
+        client=object(),
+        say=lambda text, thread_ts=None: posts.append({"text": text, "thread_ts": thread_ts}),
+        is_dm=True,
+    )
+
+    assert posts == [{"text": "DM 도 차단합니다.", "thread_ts": "1.1"}]
+
+
+def test_process_blocked_user_no_message_when_unset(app_module, monkeypatch):
+    """ALLOWED_USER_MESSAGE 가 비어 있으면 차단된 유저에게 응답이 가지 않는다."""
+    import dataclasses
+
+    override = dataclasses.replace(
+        app_module.settings,
+        allowed_user_ids=["U-ADMIN"],
+        allowed_user_message="",
+    )
+    monkeypatch.setattr(app_module, "settings", override)
+    monkeypatch.setattr(app_module, "_get_dedup", lambda: _FakeDedup())
+
+    posts = []
+    app_module._process(
+        {
+            "channel": "C-OK",
+            "ts": "1.1",
+            "text": "hi",
+            "user": "U-RANDOM",
+            "client_msg_id": "msg-user-3",
+        },
+        client=object(),
+        say=lambda text, thread_ts=None: posts.append({"text": text, "thread_ts": thread_ts}),
+        is_dm=False,
+    )
+
+    assert posts == []
+
+
+def test_process_blocked_channel_short_circuits_before_user_check(app_module, monkeypatch):
+    """채널·유저 둘 다 차단인 경우 채널 메시지 한 번만 전송 — 유저 검사로 진행 안 됨."""
+    import dataclasses
+
+    override = dataclasses.replace(
+        app_module.settings,
+        allowed_channel_ids=["C-OK"],
+        allowed_channel_message="채널 차단",
+        allowed_user_ids=["U-ADMIN"],
+        allowed_user_message="유저 차단",
+    )
+    monkeypatch.setattr(app_module, "settings", override)
+    monkeypatch.setattr(app_module, "_get_dedup", lambda: _FakeDedup())
+
+    posts = []
+    app_module._process(
+        {
+            "channel": "C-BAD",
+            "ts": "1.1",
+            "text": "hi",
+            "user": "U-RANDOM",
+            "client_msg_id": "msg-both-1",
+        },
+        client=object(),
+        say=lambda text, thread_ts=None: posts.append({"text": text, "thread_ts": thread_ts}),
+        is_dm=False,
+    )
+
+    assert posts == [{"text": "채널 차단", "thread_ts": "1.1"}]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -318,3 +318,111 @@ def test_process_worker_tolerates_missing_fields(app_module, monkeypatch):
     app_module._process_worker({})
 
     assert seen == {"event": {}, "is_dm": False}
+
+
+# --------------------------------------------------------------------------- #
+# Channel allowlist — block reply with first-channel substitution
+# --------------------------------------------------------------------------- #
+
+
+class _FakeDedup:
+    """Minimal DedupStore stand-in: reserve always succeeds, no throttle."""
+
+    def reserve(self, key, user="system"):
+        return True
+
+    def count_user_active(self, user):
+        return 0
+
+
+def test_process_blocked_channel_substitutes_first_allowed_channel(app_module, monkeypatch):
+    """비허용 채널 응답의 `{}` 는 ALLOWED_CHANNEL_IDS 의 첫 번째 채널로 치환되며,
+    Slack 채널 멘션 형식(`<#ID>`)으로 감싸 클릭 가능한 링크로 렌더되어야 한다."""
+    import dataclasses
+
+    override = dataclasses.replace(
+        app_module.settings,
+        allowed_channel_ids=["C04PPA399CP", "C08A9550X"],
+        allowed_channel_message="구루미에게 질문은 {} 채널을 이용해 주세요~",
+    )
+    monkeypatch.setattr(app_module, "settings", override)
+    monkeypatch.setattr(app_module, "_get_dedup", lambda: _FakeDedup())
+
+    posts = []
+
+    def fake_say(text, thread_ts=None):
+        posts.append({"text": text, "thread_ts": thread_ts})
+
+    event = {
+        "channel": "C-BLOCKED",
+        "ts": "1700000000.000100",
+        "text": "hi",
+        "user": "U1",
+        "client_msg_id": "msg-block-1",
+    }
+    app_module._process(event, client=object(), say=fake_say, is_dm=False)
+
+    assert posts == [
+        {
+            "text": "구루미에게 질문은 <#C04PPA399CP> 채널을 이용해 주세요~",
+            "thread_ts": "1700000000.000100",
+        }
+    ]
+
+
+def test_process_blocked_channel_message_without_placeholder_unchanged(app_module, monkeypatch):
+    """`{}` 가 없는 메시지는 가공 없이 그대로 전송되어야 한다."""
+    import dataclasses
+
+    override = dataclasses.replace(
+        app_module.settings,
+        allowed_channel_ids=["C04PPA399CP"],
+        allowed_channel_message="허용되지 않은 채널입니다.",
+    )
+    monkeypatch.setattr(app_module, "settings", override)
+    monkeypatch.setattr(app_module, "_get_dedup", lambda: _FakeDedup())
+
+    posts = []
+    app_module._process(
+        {
+            "channel": "C-X",
+            "ts": "1.1",
+            "text": "hi",
+            "user": "U1",
+            "client_msg_id": "msg-block-2",
+        },
+        client=object(),
+        say=lambda text, thread_ts=None: posts.append({"text": text, "thread_ts": thread_ts}),
+        is_dm=False,
+    )
+
+    assert posts == [{"text": "허용되지 않은 채널입니다.", "thread_ts": "1.1"}]
+
+
+def test_process_blocked_channel_no_message_when_unset(app_module, monkeypatch):
+    """ALLOWED_CHANNEL_MESSAGE 가 비어 있으면 차단된 채널에서 아무 응답도 가지 않는다."""
+    import dataclasses
+
+    override = dataclasses.replace(
+        app_module.settings,
+        allowed_channel_ids=["C04PPA399CP"],
+        allowed_channel_message="",
+    )
+    monkeypatch.setattr(app_module, "settings", override)
+    monkeypatch.setattr(app_module, "_get_dedup", lambda: _FakeDedup())
+
+    posts = []
+    app_module._process(
+        {
+            "channel": "C-X",
+            "ts": "1.1",
+            "text": "hi",
+            "user": "U1",
+            "client_msg_id": "msg-block-3",
+        },
+        client=object(),
+        say=lambda text, thread_ts=None: posts.append({"text": text, "thread_ts": thread_ts}),
+        is_dm=False,
+    )
+
+    assert posts == []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,7 +18,8 @@ def _clear_env(monkeypatch):
         "SLACK_BOT_TOKEN", "SLACK_SIGNING_SECRET", "LLM_PROVIDER", "LLM_MODEL",
         "IMAGE_PROVIDER", "IMAGE_MODEL", "OPENAI_API_KEY", "RESPONSE_LANGUAGE",
         "AGENT_MAX_STEPS", "DYNAMODB_TABLE_NAME", "AWS_REGION", "ALLOWED_CHANNEL_IDS",
-        "ALLOWED_CHANNEL_MESSAGE", "MAX_LEN_SLACK", "MAX_THROTTLE_COUNT",
+        "ALLOWED_CHANNEL_MESSAGE", "ALLOWED_USER_IDS", "ALLOWED_USER_MESSAGE",
+        "MAX_LEN_SLACK", "MAX_THROTTLE_COUNT",
         "MAX_HISTORY_CHARS", "BOT_CURSOR", "SYSTEM_MESSAGE", "PERSONA_MESSAGE", "TAVILY_API_KEY", "XAI_API_KEY", "LOG_LEVEL",
         "DEFAULT_TIMEZONE", "MAX_DOC_CHARS", "MAX_DOC_PAGES", "MAX_DOC_BYTES",
         "MAX_WEB_CHARS", "MAX_WEB_BYTES", "MAX_WEB_LINKS", "JINA_READER_BASE",
@@ -37,6 +38,8 @@ def test_defaults(monkeypatch, reload_config):
     assert s.agent_max_steps == 3
     assert s.max_len_slack == 2000
     assert s.allowed_channel_ids == []
+    assert s.allowed_user_ids == []
+    assert s.allowed_user_message == "허용된 유저만 응답합니다."
     assert s.tavily_api_key is None
 
 
@@ -75,6 +78,15 @@ def test_list_env_none_sentinel(monkeypatch, reload_config):
     monkeypatch.setenv("ALLOWED_CHANNEL_IDS", "None")
     s = reload_config()
     assert s.allowed_channel_ids == []
+
+
+def test_allowed_user_ids_parsed_from_env(monkeypatch, reload_config):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("ALLOWED_USER_IDS", "U1,U2, U3 ")
+    monkeypatch.setenv("ALLOWED_USER_MESSAGE", "허용된 유저만 응답합니다.")
+    s = reload_config()
+    assert s.allowed_user_ids == ["U1", "U2", "U3"]
+    assert s.allowed_user_message == "허용된 유저만 응답합니다."
 
 
 def test_require_slack_credentials_raises_when_missing(monkeypatch, reload_config):


### PR DESCRIPTION
  ## Summary
  - 채널/유저 차단 메시지에서 `{}` 플레이스홀더를 첫 번째 허용 채널/유저로 치환하고 Slack 멘션 형식(`<#ID>`, `<@ID>`)으로 감싸 클릭 가능한 링크로 렌더되도록 함
  - 신규 `ALLOWED_USER_IDS` / `ALLOWED_USER_MESSAGE` 환경변수로 유저 단위 화이트리스트 도입 — 채널 화이트리스트와 달리 **DM 경로에도 적용**
  - `ALLOWED_CHANNEL_MESSAGE` 디폴트를 한국어 안내 문구로 변경

  ## Changes

  ### `dc48b06` — `ALLOWED_CHANNEL_MESSAGE` 디폴트 변경
  - `ALLOWED_CHANNEL_MESSAGE` 디폴트를 한국어 안내 문구로 변경

  ## Changes

  ### `dc48b06` — `ALLOWED_CHANNEL_MESSAGE` 디폴트 변경
  - 미설정 시 `"구루미에게 질문은 {} 채널을 이용해 주세요~"` 가 적용되어 별도 env 설정 없이도 안내 동작

  ### `a1aada3` — 채널 차단 메시지 `{}` 치환
  - `app.py` 의 채널 차단 분기에서 `ALLOWED_CHANNEL_MESSAGE` 의 `{}` 를 `<#FIRST_CHANNEL_ID>` 로 치환
  - `replace("{}", ...)` 사용 — `.format()` 보다 안전 (다른 `{}` 가 우연히 들어가도 KeyError 안 남)
  - `tests/test_app.py` 에 3개 회귀 테스트 추가

  ### `075027b` — 유저 화이트리스트 추가
  - `src/config.py` 에 `allowed_user_ids`, `allowed_user_message` 필드 + env 파싱
  - `app.py` 에 유저 검사 분기 — 채널 검사 직후, throttle 검사 직전. **`is_dm` 무관하게 적용** (채널 검사와의 핵심 차이)
  - 차단 메시지의 `{}` 는 `<@FIRST_USER_ID>` 로 치환
  - 검사 순서: 채널 → 유저 (채널 차단 시 유저 검사로 진행 안 함)
  - `.env.example`, `serverless.yml`, `.github/workflows/push.yml`, `README.md` 환경변수 등록
  - `tests/test_app.py` 에 4개 회귀 테스트

  ## Behavior Matrix

  | 상황 | 동작 |
  |------|------|
  | `ALLOWED_USER_IDS` 빈 값 | 모든 유저 허용 |
  | 채널 비허용 (DM 아님) | 채널 메시지 응답, 유저 검사로 진행 안 함 |
  | 채널 허용 + 유저 비허용 | 유저 메시지 응답 (`<@U1>` 치환) |
  | DM + 유저 비허용 | 유저 메시지 응답 (DM 도 차단) |
  | DM + 유저 허용 | 정상 진행 |

  ## Breaking Changes

  - `ALLOWED_CHANNEL_MESSAGE` 디폴트값이 빈 문자열에서 `"구루미에게 질문은 {} 채널을 이용해 주세요~"` 로 변경됨. 기존에 빈 디폴트를 가정하고 운영하던 환경에서 `ALLOWED_CHANNEL_IDS` 만 설정하고 메시지를 비워둔 경우, 이전엔 무응답이었으나 이제는 디폴트 안내가 전송됨. 무응답 동작이 필요하면
  `ALLOWED_CHANNEL_MESSAGE=""` 를 명시적으로 지정.

  ## Test Plan
  - [x] `python -m pytest` — 전체 217개 통과 (기존 205 + 신규 12)
  - [x] 채널 차단 + `{}` 치환 — `<#CHANNEL_ID>` 멘션 렌더
  - [x] 유저 차단 + `{}` 치환 — `<@USER_ID>` 멘션 렌더
  - [x] DM 경로에서 비허용 유저 차단
  - [x] 채널·유저 동시 차단 시 채널 메시지 단 한 번만 전송
  - [x] `ALLOWED_USER_MESSAGE` 비어 있을 때 무응답
  - [ ] 운영 배포 후 실제 Slack 클라이언트에서 멘션 렌더 수동 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 수준 접근 제어 추가: 허용된 사용자 목록에 없는 사용자를 채널 및 다이렉트 메시지에서 차단할 수 있습니다.
  * 메시지 자동화: 차단 메시지의 자리 표시자({})가 첫 번째 허용된 채널 또는 사용자 멘션으로 자동 변환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->