### PR TITLE
feat(llms): add Upstage (Solar) LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,11 +15,11 @@ SSM_PARAMS_PREFIX="/gurumi-bot/apps"
 SSM_CACHE_TTL_SECONDS=300
 
 # --- LLM / text (default: openai / gpt-4o-mini) ---
-LLM_PROVIDER="openai"            # openai | xai | bedrock
-LLM_MODEL="gpt-5.4"              # OpenAI: gpt-5.5  |  xAI: grok-4-3  |  Bedrock: us.anthropic.claude-opus-4-6-v1 / amazon.nova-pro-v1:0
+LLM_PROVIDER="openai"            # openai | xai | bedrock | upstage
+LLM_MODEL="gpt-5.4"              # OpenAI: gpt-5.5  |  xAI: grok-4-3  |  Bedrock: us.anthropic.claude-opus-4-6-v1 / amazon.nova-pro-v1:0  |  Upstage: solar-pro2
 
 # --- Image generation (default: openai / gpt-image-1) ---
-IMAGE_PROVIDER="openai"          # openai | xai | bedrock
+IMAGE_PROVIDER="openai"          # openai | xai | bedrock (upstage has no image generation)
 IMAGE_MODEL="gpt-image-1"        # OpenAI: gpt-image-1  |  xAI: grok-imagine-image / grok-imagine-image-quality  |  Bedrock: amazon.nova-canvas-v1:0 / amazon.titan-image-generator-v2:0
 
 IMAGE_MODEL_GPT="gpt-image-1"         # OpenAI image model used by the `/img-gpt` slash command (independent of IMAGE_PROVIDER/IMAGE_MODEL)
@@ -28,6 +28,7 @@ IMAGE_MODEL_XAI="grok-imagine-image"  # xAI image model used by the `/img-xai` s
 # --- Providers (required by provider in use) ---
 OPENAI_API_KEY="sk-your-openai-api-key"
 XAI_API_KEY=""                   # required when LLM_PROVIDER=xai or IMAGE_PROVIDER=xai. Get at https://console.x.ai
+UPSTAGE_API_KEY=""               # required when LLM_PROVIDER=upstage (text only). Get at https://console.upstage.ai
 TAVILY_API_KEY=""                # optional, enables richer web search
 
 # --- Agent behavior ---

--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ Slack 멘션·DM 을 AWS Lambda 에서 처리하고, OpenAI · AWS Bedrock · xA
 | `SLACK_BOT_TOKEN` | (localtest only) | — | `localtest.py` 에서만 사용. Lambda 런타임은 SSM 만 본다 |
 | `OPENAI_API_KEY` | OpenAI 사용 시 | — | OpenAI API 키 |
 | `XAI_API_KEY` | xAI 사용 시 | — | xAI (Grok) API 키 — https://console.x.ai |
+| `UPSTAGE_API_KEY` | Upstage 사용 시 | — | Upstage (Solar) API 키 — https://console.upstage.ai |
 | `TAVILY_API_KEY` | | — | 설정 시 Tavily 웹 검색 활성화 |
-| `LLM_PROVIDER` | | `openai` | `openai` / `bedrock` / `xai` |
+| `LLM_PROVIDER` | | `openai` | `openai` / `bedrock` / `xai` / `upstage` |
 | `LLM_MODEL` | | `gpt-4o-mini` | 텍스트 모델 |
-| `IMAGE_PROVIDER` | | `openai` | `openai` / `bedrock` / `xai` |
+| `IMAGE_PROVIDER` | | `openai` | `openai` / `bedrock` / `xai` (upstage 는 이미지 생성 미지원) |
 | `IMAGE_MODEL` | | `gpt-image-1` | 이미지 모델 |
 | `AGENT_MAX_STEPS` | | `6` | tool 루프 최대 iteration |
 | `RESPONSE_LANGUAGE` | | `ko` | `ko` / `en` |
@@ -213,7 +214,7 @@ aws iam attach-role-policy --role-name "${NAME}" --policy-arn "arn:aws:iam::${AC
 
 ### 2. GitHub 저장소 설정
 
-- **Secrets**: `AWS_ACCOUNT_ID`, `OPENAI_API_KEY`, `XAI_API_KEY`(xAI 사용 시), `TAVILY_API_KEY`(선택). Slack 시크릿은 SSM Parameter Store 에 별도 등록 — CI 시크릿 아님.
+- **Secrets**: `AWS_ACCOUNT_ID`, `OPENAI_API_KEY`, `XAI_API_KEY`(xAI 사용 시), `UPSTAGE_API_KEY`(Upstage 사용 시), `TAVILY_API_KEY`(선택). Slack 시크릿은 SSM Parameter Store 에 별도 등록 — CI 시크릿 아님.
 - **Variables**: `LLM_PROVIDER`, `LLM_MODEL`, `IMAGE_PROVIDER`, `IMAGE_MODEL`, `RESPONSE_LANGUAGE`, `ALLOWED_CHANNEL_IDS`, `ALLOWED_CHANNEL_MESSAGE`, `ALLOWED_USER_IDS`, `ALLOWED_USER_MESSAGE`, `SYSTEM_MESSAGE`, `PERSONA_MESSAGE`, `BOT_CURSOR`, `MAX_LEN_SLACK`, `MAX_OUTPUT_TOKENS`, `MAX_THROTTLE_COUNT`, `MAX_HISTORY_CHARS`, `AGENT_MAX_STEPS`, `LOG_LEVEL`, `DEFAULT_TIMEZONE`, `MAX_DOC_CHARS`, `MAX_DOC_PAGES`, `MAX_DOC_BYTES`, `MAX_WEB_CHARS`, `MAX_WEB_BYTES`, `MAX_WEB_LINKS`, `MAX_IMAGE_BYTES`, `JINA_READER_BASE`, `SSM_PARAMS_PREFIX`, `SSM_CACHE_TTL_SECONDS`
 
 ### 3. 배포
@@ -255,7 +256,7 @@ src/
 ├── slack_helpers.py         메시지 분할·스트리밍·사용자 캐시
 ├── config.py                Settings (env → dataclass, lazy validation)
 ├── logging_utils.py         구조화 JSON 로깅 + request_id
-├── llms/                    LLM provider 패키지 (OpenAI · xAI · Bedrock 분기)
+├── llms/                    LLM provider 패키지 (OpenAI · xAI · Bedrock · Upstage 분기)
 └── tools/                   Tool 패키지 (@tool 데코레이터로 self-register)
 ```
 

--- a/localtest.py
+++ b/localtest.py
@@ -225,6 +225,10 @@ def main() -> None:
         if not settings.xai_api_key:
             print("[오류] XAI_API_KEY가 설정되지 않았습니다. .env.local 을 확인하세요.", file=sys.stderr)
             sys.exit(1)
+    elif settings.llm_provider == "upstage":
+        if not settings.upstage_api_key:
+            print("[오류] UPSTAGE_API_KEY가 설정되지 않았습니다. .env.local 을 확인하세요.", file=sys.stderr)
+            sys.exit(1)
 
     llm = get_llm(
         provider=settings.llm_provider,
@@ -232,7 +236,7 @@ def main() -> None:
         image_provider=settings.image_provider,
         image_model=settings.image_model,
         region=settings.aws_region,
-        api_keys={"xai": settings.xai_api_key},
+        api_keys={"xai": settings.xai_api_key, "upstage": settings.upstage_api_key},
     )
 
     slack_client = _build_slack_client(settings.slack_bot_token)

--- a/serverless.yml
+++ b/serverless.yml
@@ -37,6 +37,7 @@ provider:
     # --- secrets: LLM provider keys ---
     OPENAI_API_KEY: ${env:OPENAI_API_KEY, ''}
     XAI_API_KEY: ${env:XAI_API_KEY, ''}
+    UPSTAGE_API_KEY: ${env:UPSTAGE_API_KEY, ''}
     # --- secrets: Web search ---
     TAVILY_API_KEY: ${env:TAVILY_API_KEY, ''}
     # --- vars: LLM / Image ---

--- a/src/config.py
+++ b/src/config.py
@@ -22,7 +22,7 @@ _load_env_local()
 
 
 _VALID_LANGUAGES = {"ko", "en"}
-_VALID_PROVIDERS = {"openai", "bedrock", "xai"}
+_VALID_PROVIDERS = {"openai", "bedrock", "xai", "upstage"}
 
 
 def _int_env(name: str, default: int, minimum: int = 1) -> int:
@@ -121,6 +121,7 @@ class Settings:
     persona_message: str | None = None
     tavily_api_key: str | None = None
     xai_api_key: str | None = None
+    upstage_api_key: str | None = None
     log_level: str = "INFO"
     default_timezone: str = "Asia/Seoul"
     max_doc_chars: int = 20_000
@@ -148,6 +149,7 @@ class Settings:
         persona_message = os.getenv("PERSONA_MESSAGE", "").strip() or None
         tavily_key = os.getenv("TAVILY_API_KEY", "").strip() or None
         xai_key = os.getenv("XAI_API_KEY", "").strip() or None
+        upstage_key = os.getenv("UPSTAGE_API_KEY", "").strip() or None
         return cls(
             slack_bot_token=os.getenv("SLACK_BOT_TOKEN", "").strip(),
             llm_provider=llm_provider,
@@ -184,6 +186,7 @@ class Settings:
             persona_message=persona_message,
             tavily_api_key=tavily_key,
             xai_api_key=xai_key,
+            upstage_api_key=upstage_key,
             log_level=os.getenv("LOG_LEVEL", "INFO").strip().upper() or "INFO",
             default_timezone=_tz_env("DEFAULT_TIMEZONE", "Asia/Seoul"),
             max_doc_chars=_int_env("MAX_DOC_CHARS", 20_000, minimum=1000),

--- a/src/llms/factory.py
+++ b/src/llms/factory.py
@@ -5,6 +5,7 @@ from src.llms.base import LLMProvider
 from src.llms.bedrock import BedrockProvider
 from src.llms.composite import _CompositeProvider
 from src.llms.openai import OpenAIProvider
+from src.llms.upstage import UpstageProvider
 from src.llms.xai import XAIProvider
 
 
@@ -29,6 +30,8 @@ def get_llm(
             return BedrockProvider(model=model, image_model=image_model, region=region)
         if p == "xai":
             return XAIProvider(model=model, image_model=image_model, api_key=api_keys.get("xai"))
+        if p == "upstage":
+            return UpstageProvider(model=model, image_model=image_model, api_key=api_keys.get("upstage"))
         return OpenAIProvider(model=model, image_model=image_model)
 
     text = build(provider)

--- a/src/llms/upstage.py
+++ b/src/llms/upstage.py
@@ -1,0 +1,37 @@
+"""UpstageProvider — Solar chat at https://api.upstage.ai/v1."""
+from __future__ import annotations
+
+from src.llms.openai_wire import _OpenAICompatProvider
+
+
+class UpstageProvider(_OpenAICompatProvider):
+    """Upstage (Solar) — OpenAI-wire compatible, different base URL.
+
+    Models (text only):
+      solar-pro2, solar-pro, solar-mini, ...
+
+    All current Solar chat models accept `max_tokens` + `temperature` the
+    classic way, so the inherited `_token_params` default is correct — no
+    `max_completion_tokens` split.
+
+    Upstage has no image generation/edit endpoint. Because IMAGE_PROVIDER
+    falls back to LLM_PROVIDER, `LLM_PROVIDER=upstage` without an explicit
+    IMAGE_PROVIDER would otherwise route `generate_image` to the OpenAI SDK
+    against api.upstage.ai and fail with an opaque error. Raise a clear
+    message instead so `ToolExecutor` surfaces it to the LLM as recoverable.
+    """
+
+    BASE_URL = "https://api.upstage.ai/v1"
+    API_KEY_ENV_VAR = "UPSTAGE_API_KEY"
+
+    def generate_image(self, prompt: str) -> bytes:
+        raise NotImplementedError(
+            "generate_image is not supported by Upstage. "
+            "Switch IMAGE_PROVIDER to 'openai', 'xai', or 'bedrock'."
+        )
+
+    def edit_image(self, prompt: str, images: list[tuple[bytes, str]]) -> bytes:
+        raise NotImplementedError(
+            "edit_image is not supported by Upstage. "
+            "Switch IMAGE_PROVIDER to 'openai' or 'xai' for editing."
+        )

--- a/src/runtime.py
+++ b/src/runtime.py
@@ -63,7 +63,7 @@ def _get_llm():
             image_provider=settings.image_provider,
             image_model=settings.image_model,
             region=settings.aws_region,
-            api_keys={"xai": settings.xai_api_key},
+            api_keys={"xai": settings.xai_api_key, "upstage": settings.upstage_api_key},
         )
     return _llm
 

--- a/tests/llms/test_factory.py
+++ b/tests/llms/test_factory.py
@@ -4,7 +4,37 @@ from __future__ import annotations
 from src.llms import get_llm
 from src.llms.composite import _CompositeProvider
 from src.llms.openai import OpenAIProvider
+from src.llms.upstage import UpstageProvider
 from src.llms.xai import XAIProvider
+
+
+def test_get_llm_builds_upstage_provider():
+    provider = get_llm(
+        provider="upstage",
+        model="solar-pro2",
+        image_provider="upstage",
+        image_model="",
+        region="us-east-1",
+        api_keys={"upstage": "up-secret"},
+    )
+    assert isinstance(provider, UpstageProvider)
+    assert provider._api_key == "up-secret"
+
+
+def test_get_llm_composite_upstage_text_openai_image():
+    """Upstage has no image support, so a typical setup pairs it with a
+    different image provider through _CompositeProvider."""
+    provider = get_llm(
+        provider="upstage",
+        model="solar-pro2",
+        image_provider="openai",
+        image_model="gpt-image-1",
+        region="us-east-1",
+        api_keys={"upstage": "up-key"},
+    )
+    assert isinstance(provider, _CompositeProvider)
+    assert isinstance(provider.text, UpstageProvider)
+    assert isinstance(provider.image, OpenAIProvider)
 
 
 def test_get_llm_builds_xai_provider():

--- a/tests/llms/test_upstage.py
+++ b/tests/llms/test_upstage.py
@@ -1,0 +1,92 @@
+"""Tests for src.llms.upstage."""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.llms.upstage import UpstageProvider
+
+
+def _openai_completion(content="", tool_calls=None, finish="stop"):
+    choice = MagicMock()
+    choice.finish_reason = finish
+    choice.message.content = content
+    choice.message.tool_calls = tool_calls or []
+    completion = MagicMock()
+    completion.choices = [choice]
+    completion.usage.prompt_tokens = 10
+    completion.usage.completion_tokens = 20
+    return completion
+
+
+def _openai_tool_call(call_id, name, args_obj):
+    tc = MagicMock()
+    tc.id = call_id
+    tc.function.name = name
+    tc.function.arguments = json.dumps(args_obj)
+    return tc
+
+
+def test_upstage_provider_uses_upstage_base_url_and_api_key():
+    """UpstageProvider must instantiate the OpenAI client with the Upstage
+    base URL and explicit api_key, so traffic goes to api.upstage.ai."""
+    provider = UpstageProvider(
+        model="solar-pro2",
+        image_model="",
+        api_key="up-test",
+    )
+    with patch("openai.OpenAI") as openai_ctor:
+        openai_ctor.return_value = MagicMock()
+        provider._get_client()
+    kwargs = openai_ctor.call_args.kwargs
+    assert kwargs.get("base_url") == "https://api.upstage.ai/v1"
+    assert kwargs.get("api_key") == "up-test"
+
+
+def test_upstage_chat_parses_tool_calls():
+    """Solar returns the same wire shape as OpenAI for tool calls; the shared
+    parser must turn them into ToolCall objects."""
+    provider = UpstageProvider(model="solar-pro2", image_model="", api_key="x")
+    provider._client = MagicMock()
+    tc = _openai_tool_call("call_u1", "search_web", {"query": "solar"})
+    provider._client.chat.completions.create.return_value = _openai_completion(
+        tool_calls=[tc], finish="tool_calls"
+    )
+    result = provider.chat(
+        system="s",
+        messages=[],
+        tools=[{"name": "search_web", "description": "", "parameters": {"type": "object"}}],
+    )
+    assert result.stop_reason == "tool_use"
+    assert result.tool_calls[0].name == "search_web"
+    assert result.tool_calls[0].arguments == {"query": "solar"}
+
+
+def test_upstage_chat_uses_legacy_max_tokens():
+    """All current Solar chat models accept max_tokens + temperature;
+    UpstageProvider must not switch to max_completion_tokens (OpenAI-only)."""
+    provider = UpstageProvider(model="solar-pro2", image_model="", api_key="x")
+    provider._client = MagicMock()
+    provider._client.chat.completions.create.return_value = _openai_completion(content="hi")
+    provider.chat(system="s", messages=[])
+    kwargs = provider._client.chat.completions.create.call_args.kwargs
+    assert "max_tokens" in kwargs
+    assert "temperature" in kwargs
+    assert "max_completion_tokens" not in kwargs
+
+
+def test_upstage_generate_image_raises():
+    """Upstage has no image generation endpoint; misrouting there (e.g.
+    IMAGE_PROVIDER falling back to LLM_PROVIDER=upstage) must fail with a
+    clear message rather than an opaque SDK error."""
+    provider = UpstageProvider(model="solar-pro2", image_model="", api_key="x")
+    with pytest.raises(NotImplementedError, match="not supported by Upstage"):
+        provider.generate_image("a cat")
+
+
+def test_upstage_edit_image_raises():
+    provider = UpstageProvider(model="solar-pro2", image_model="", api_key="x")
+    with pytest.raises(NotImplementedError, match="not supported by Upstage"):
+        provider.edit_image("make it a sketch", [(b"\x89PNG", "image/png")])


### PR DESCRIPTION
## Summary
- LLM provider로 Upstage(Solar)를 추가한다. Upstage는 OpenAI chat-completions wire format을 그대로 지원하므로, 기존 xAI와 동일한 `_OpenAICompatProvider` 패턴으로 최소 변경만으로 통합된다.
- 텍스트 전용 provider — `LLM_PROVIDER=upstage`, `LLM_MODEL=solar-pro2`, `UPSTAGE_API_KEY`로 사용.

## Changes
- `src/llms/upstage.py` (신규) — `UpstageProvider(_OpenAICompatProvider)`. base_url `https://api.upstage.ai/v1`, `UPSTAGE_API_KEY`. Solar 모델은 legacy `max_tokens`+`temperature`라 상속 기본값 그대로 정확. Upstage는 이미지 생성 API가 없고 `IMAGE_PROVIDER`가 `LLM_PROVIDER`로 기본 폴백되므로, `generate_image`/`edit_image`는 불투명한 SDK 에러 대신 명확한 `NotImplementedError`를 raise (Bedrock의 `edit_image`와 동일한 방식 — `ToolExecutor`가 LLM에 복구 가능 에러로 surface).
- `src/llms/factory.py` — `upstage` 분기 + import.
- `src/config.py` — `_VALID_PROVIDERS`에 `upstage` 추가, `upstage_api_key` 필드, `UPSTAGE_API_KEY` 로드.
- `src/runtime.py` / `localtest.py` — `get_llm`의 `api_keys`에 `upstage` 배선 (`/img-*` 슬래시커맨드 경로는 이미지 미지원이라 제외).
- `.env.example` / `serverless.yml` / `README.md` — provider 목록·env 문서화.
- `tests/llms/test_upstage.py` (신규) + `tests/llms/test_factory.py` — base_url/api_key 배선, tool_calls 파싱, legacy 토큰 파라미터, 이미지 메서드 raise 검증.

## Test Plan
- [x] `python -m pytest` → 549 passed (신규 9개 포함)
- [ ] `LLM_PROVIDER=upstage LLM_MODEL=solar-pro2 UPSTAGE_API_KEY=... python localtest.py` 로 실제 chat 응답 확인
- [ ] `IMAGE_PROVIDER`를 지정하지 않고 `LLM_PROVIDER=upstage`만 설정한 뒤 이미지 생성 요청 시 명확한 미지원 안내가 나오는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upstage(Solar) LLM 제공자 지원이 추가되었습니다.
  * Upstage용 API 키를 환경설정과 배포 설정에서 사용할 수 있습니다.
  * LLM과 이미지 제공자를 서로 다르게 구성할 수 있는 조합이 확장되었습니다.

* **Bug Fixes**
  * Upstage 선택 시 필요한 API 키 검사가 추가되었습니다.
  * Upstage가 이미지 생성/편집을 지원하지 않음을 명확히 반영했습니다.

* **Documentation**
  * 환경 변수와 배포 안내가 최신 설정에 맞게 업데이트되었습니다.

* **Tests**
  * Upstage 연결, 응답 처리, 이미지 미지원 동작에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->